### PR TITLE
Speed up compilation of native libraries using all available cores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,29 +28,29 @@ RUN apt-get -y update && \
 
 # building libwebp
 RUN echo "build libwebp" && git clone -b "v$LIB_WEBP_VERSION" --single-branch --depth 1 https://chromium.googlesource.com/webm/libwebp && cd libwebp && \
-  ./autogen.sh && ./configure --enable-shared --enable-libwebpdecoder --enable-libwebpdemux --enable-libwebpmux --enable-static=no && make && make install && ldconfig && cd .. && \
+  ./autogen.sh && ./configure --enable-shared --enable-libwebpdecoder --enable-libwebpdemux --enable-libwebpmux --enable-static=no && make -j$(nproc) && make install && ldconfig && cd .. && \
   rm -rf libwebp
 
 # building libaom
 RUN echo "build libaom" &&  git clone -b "v$LIB_AOM_VERSION" --single-branch --depth 1 https://aomedia.googlesource.com/aom && mkdir build_aom && cd build_aom && \
-  cmake ../aom/ -DENABLE_TESTS=0 -DBUILD_SHARED_LIBS=1 && make && make install && ldconfig && cd .. && \
+  cmake ../aom/ -DENABLE_TESTS=0 -DBUILD_SHARED_LIBS=1 && make -j$(nproc) && make install && ldconfig && cd .. && \
   rm -rf aom build_aom
 
 # building libheif
 RUN echo "build libheif" && curl -fsL https://github.com/strukturag/libheif/releases/download/v${LIB_HEIF_VERSION}/libheif-${LIB_HEIF_VERSION}.tar.gz -o libheif.tar.gz && \
   tar -xzvf libheif.tar.gz && cd libheif-${LIB_HEIF_VERSION} && \
-  ./autogen.sh && ./configure && make && make install && ldconfig && cd .. && \
+  ./autogen.sh && ./configure && make -j$(nproc) && make install && ldconfig && cd .. && \
   rm -rf libheif-${LIB_HEIF_VERSION} libheif.tar.gz
 
 # building imagemagick
 RUN echo "build imagemagick" && git clone -b "$IM_VERSION" --single-branch --depth 1 https://github.com/ImageMagick/ImageMagick.git && cd ImageMagick && \
-  ./configure --without-magick-plus-plus --disable-static --disable-docs --disable-dependency-tracking --with-modules && make && make install && ldconfig && cd .. && \
+  ./configure --without-magick-plus-plus --disable-static --disable-docs --disable-dependency-tracking --with-modules && make -j$(nproc) && make install && ldconfig && cd .. && \
   rm -rf ImageMagick
 
 # building libvips
 RUN echo "build libvips" && curl -fsL https://github.com/libvips/libvips/releases/download/v${LIB_VIPS_VERSION}/vips-${LIB_VIPS_VERSION}.tar.gz -o libvips.tar.gz && \
   tar -xzvf libvips.tar.gz && cd vips-${LIB_VIPS_VERSION} && \
-  ./configure && make && make install && ldconfig && cd .. && \
+  ./configure && make -j$(nproc) && make install && ldconfig && cd .. && \
   rm -rf vips-${LIB_VIPS_VERSION} libvips.tar.gz
 
 # Install NodeJS


### PR DESCRIPTION
Use all available cores to build with make.
There is no need to parallelize the install target because it is an IO-bound operation.

On my 16-core machine building the docker image went from 17min to roughly 4min.

As I understand, you're already caching the docker layers, so as long as nothing changes, the GitHub Action is pretty fast (~3m30s). However, whenever something changes it takes much more (~25m). I think it may be worth checking out the use of [ccache](https://ccache.dev/) to speed up compilation for those cases. It essentially caches the objects that are the output of the compiler. So, as long as the source file, the compiler and the flags are the same, you don't need to actually compile anything. I've seen a [GH Action for it](https://github.com/hendrikmuhs/ccache-action), but I doubt it will work out of the box to build a docker image. Most likely, you'll need to install `ccache` in your Dockerfile, make sure it's used (`export PATH="/usr/lib/ccache:/usr/local/opt/ccache/libexec:$PATH"` it's the simplest way) and of course restore and save the `.cache` directory across builds.

Let me know if you need any help with that. It's pretty easy to set up.